### PR TITLE
Replacing example with correct class name

### DIFF
--- a/src/docs/spring-datasource.adoc
+++ b/src/docs/spring-datasource.adoc
@@ -17,7 +17,7 @@ class MyConfiguration {
 
     @PostConstruct
     private void instrumentDataSource() {
-        new DataSourcePoolMetrics(
+        new DataSourceMetrics(
             dataSource,
             metadataProviders,
             "data.source", // base metric name


### PR DESCRIPTION
The class named `DataSourcePoolMetrics` is referenced, but does not exist in the project. I replace it here with a reference to the class `DataSourceMetrics`, which is a valid metrics binder in the Micrometer project.